### PR TITLE
Add seed aggregation, parse-only eval, robust parsing, README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # SpuriVerse
-This is the official repository for Escaping the SpuriVerse: Can Large Vision-Language Models Generalize Beyond Seen Spurious Correlations?
+
+This is the official repository for **"Escaping the SpuriVerse: Can Large Vision-Language Models Generalize Beyond Seen Spurious Correlations?"**
+
+📄 **Paper:** [arXiv:2506.18322](https://arxiv.org/pdf/2506.18322) &nbsp;|&nbsp; 🤗 **Dataset:** [yanyiwei/SpuriVerse](https://huggingface.co/datasets/yanyiwei/SpuriVerse)
+
+*Yiwei Yang, Chung Peng Lee, Shangbin Feng, Dora Zhao, Bingbing Wen, Anthony Z. Liu, Yulia Tsvetkov, Bill Howe*
+
+SpuriVerse is a benchmark of **124 distinct types of spurious correlations** extracted from real-world VQA datasets, each with 1 realistic and 10 synthetic samples for a total of **1,364 multiple-choice questions**. We use it to study whether large vision-language models can generalize beyond the spurious correlations they have seen. State-of-the-art models reach only ~37% accuracy on the benchmark; finetuning on diverse synthetic spurious examples raises this to ~78%.
 
 ## Dependencies
 ```bash
@@ -47,7 +54,7 @@ This includes all the images in the anchor set, spurious group images, and their
 1. evaluate the performance of a VLM on SpuriVerse
 2. finetune a VLM on SpuriVerse's anchor or spurious group images
 
-To download the SpuriVerse artifact, run the script:
+The artifact is hosted on the Hugging Face Hub at [yanyiwei/SpuriVerse](https://huggingface.co/datasets/yanyiwei/SpuriVerse). To download it, run the script:
 ```bash
 python3 adhoc/prepare_data.py
 ```
@@ -86,3 +93,14 @@ The `finetune` directory contains the code for finetuning a VLM on a subset of S
 1. `finetune.py` is the main script for finetuning, consisting of various args to configure the experiments.
 2. `scripts/ablation.sh` experiments with different subsample sizes, which represent the size of spurious samples used for finetuning.
 3. `scripts/generalization.sh` experiments with different finetuning strategies, including finetuning on `anchor_set`, `spurious_group`, and `non_spurious` samples.
+
+## Citation
+If you find SpuriVerse useful in your research, please cite:
+```bibtex
+@article{yang2025spuriverse,
+  title   = {Escaping the SpuriVerse: Can Large Vision-Language Models Generalize Beyond Seen Spurious Correlations?},
+  author  = {Yang, Yiwei and Lee, Chung Peng and Feng, Shangbin and Zhao, Dora and Wen, Bingbing and Liu, Anthony Z. and Tsvetkov, Yulia and Howe, Bill},
+  journal = {arXiv preprint arXiv:2506.18322},
+  year    = {2025}
+}
+```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This is the official repository for **"Escaping the SpuriVerse: Can Large Vision
 
 SpuriVerse is a benchmark of **124 distinct types of spurious correlations** extracted from real-world VQA datasets, each with 1 realistic and 10 synthetic samples for a total of **1,364 multiple-choice questions**. We use it to study whether large vision-language models can generalize beyond the spurious correlations they have seen. State-of-the-art models reach only ~37% accuracy on the benchmark; finetuning on diverse synthetic spurious examples raises this to ~78%.
 
+## Benchmark Structure
+
+Three terms are used throughout this repository and the paper:
+
+- **Anchor set** — the 124 real-world VQA samples (one per spurious-correlation type), each a case where a strong VLM fails due to a validated spurious correlation.
+- **Spurious group** — the 10 synthetic counterfactual samples generated for each anchor, sharing that anchor's spurious pattern (1,240 samples total).
+- **Non-spurious** — control samples drawn from the original benchmarks (AOKVQA, SeedBench, SeedBench-2, NaturalBench) that do *not* exhibit the spurious correlation, used as a baseline.
+
+The repository is organized around the three stages of the paper: **curation** of the benchmark (`curation/`), **evaluation** of VLMs on it (`adhoc/`), and **finetuning** to escape the spurious correlations (`finetune/`). See [Usage](#usage) below.
+
 ## Dependencies
 ```bash
 pip install -r requirements.txt
@@ -54,9 +64,14 @@ This includes all the images in the anchor set, spurious group images, and their
 1. evaluate the performance of a VLM on SpuriVerse
 2. finetune a VLM on SpuriVerse's anchor or spurious group images
 
-The artifact is hosted on the Hugging Face Hub at [yanyiwei/SpuriVerse](https://huggingface.co/datasets/yanyiwei/SpuriVerse). To download it, run the script:
+The artifact is hosted on the Hugging Face Hub at [yanyiwei/SpuriVerse](https://huggingface.co/datasets/yanyiwei/SpuriVerse). The script below pulls it directly from the Hub (via `load_dataset("yanyiwei/SpuriVerse")`) and unpacks the anchor and spurious-group images into the local directories used by the rest of the pipeline:
 ```bash
 python3 adhoc/prepare_data.py
+```
+You can also load it directly in your own code:
+```python
+from datasets import load_dataset
+ds = load_dataset("yanyiwei/SpuriVerse")  # each row: anchor `image` + `spurious_group_1..10`
 ```
 
 ### Full Benchmarks

--- a/adhoc/aggregate_seed_eval.py
+++ b/adhoc/aggregate_seed_eval.py
@@ -1,0 +1,179 @@
+import os
+import argparse
+import pandas as pd
+from pathlib import Path
+from dotenv import load_dotenv
+import glob
+import numpy as np
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from utils.constants import SUPPORTED_MODELS
+from utils.evaluation import compute_acc
+
+load_dotenv()
+
+
+def aggregate_seed_results(model_type, prompt_strategy, data_type):
+    """
+    Aggregate evaluation results across different seeds for a given model, prompt strategy, and data type.
+
+    Args:
+        model_type (str): The model type (e.g., 'gpt-4o', 'llava-1.6')
+        prompt_strategy (str): The prompting strategy (e.g., 'direct_prompting')
+        data_type (str): The data type ('anchor', 'spurious_group', or 'non_spurious')
+
+    Returns:
+        pd.DataFrame: Aggregated results with mean and std across seeds
+    """
+    results_dir = (
+        Path(os.getenv("ADHOC_EVAL_RESULTS_DIR")) / model_type / prompt_strategy
+    )
+
+    # Find all seed result files for the given data type
+    pattern = f"{data_type}_seed_*_eval_results.csv"
+    seed_files = glob.glob(str(results_dir / pattern))
+
+    if not seed_files:
+        print(f"No seed files found for {model_type}/{prompt_strategy}/{data_type}")
+        return None
+
+    print(
+        f"Found {len(seed_files)} seed files for {model_type}/{prompt_strategy}/{data_type}"
+    )
+
+    # Load all seed results
+    seed_results = []
+    seed_accuracies = []
+
+    for seed_file in seed_files:
+        df = pd.read_csv(seed_file)
+        seed_results.append(df)
+
+        # Calculate accuracy for this seed
+        acc = compute_acc(df)
+        seed_accuracies.append(acc)
+
+        # Extract seed number from filename
+        seed_num = seed_file.split("seed_")[1].split("_")[0]
+        # print(f"Seed {seed_num}: {acc:.4f} accuracy")
+
+    # Calculate mean and std accuracy across seeds
+    mean_acc = np.mean(seed_accuracies)
+    std_acc = np.std(seed_accuracies)
+
+    # print(f"Mean accuracy: {mean_acc:.4f} ± {std_acc:.4f}")
+
+    # Create aggregated results DataFrame
+    # For now, we'll just create a summary with accuracy statistics
+    # You could extend this to aggregate other metrics if needed
+    aggregated_results = pd.DataFrame(
+        {
+            "model_type": [model_type],
+            "prompt_strategy": [prompt_strategy],
+            "data_type": [data_type],
+            "num_seeds": [len(seed_files)],
+            "mean_accuracy": [mean_acc],
+            "std_accuracy": [std_acc],
+            "seed_accuracies": [seed_accuracies],
+        }
+    )
+
+    return aggregated_results
+
+
+def main(args):
+    """
+    Aggregate evaluation results across seeds for specified configurations.
+    """
+    results = []
+
+    # Process each requested data type
+    if args.anchor:
+        result = aggregate_seed_results(args.model_type, args.prompt_strategy, "anchor")
+        if result is not None:
+            results.append(result)
+
+    if args.spurious_group:
+        result = aggregate_seed_results(
+            args.model_type, args.prompt_strategy, "spurious_group"
+        )
+        if result is not None:
+            results.append(result)
+
+    if args.non_spurious:
+        result = aggregate_seed_results(
+            args.model_type, args.prompt_strategy, "non_spurious"
+        )
+        if result is not None:
+            results.append(result)
+
+    if not results:
+        print("No results to aggregate.")
+        return
+
+    # Combine all results
+    combined_results = pd.concat(results, ignore_index=True)
+
+    # Save aggregated results
+    save_dir = (
+        Path(os.getenv("ADHOC_EVAL_RESULTS_DIR"))
+        / args.model_type
+        / args.prompt_strategy
+    )
+    save_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = save_dir / "aggregated_seed_results.csv"
+    combined_results.to_csv(output_file, index=False)
+
+    print(f"\nAggregated results saved to: {output_file}")
+    print("\nSummary:")
+    for _, row in combined_results.iterrows():
+        print(
+            f"{row['data_type']}: {row['mean_accuracy']:.4f} ± {row['std_accuracy']:.4f} (n={row['num_seeds']})"
+        )
+    print(
+        f"Delta Non-Spurious - Anchor: {combined_results.loc[combined_results['data_type'] == 'non_spurious', 'mean_accuracy'].values[0] - combined_results.loc[combined_results['data_type'] == 'anchor', 'mean_accuracy'].values[0]:.4f}"
+    )
+    print(
+        f"Delta Non-Spurious - Spurious Group: {combined_results.loc[combined_results['data_type'] == 'non_spurious', 'mean_accuracy'].values[0] - combined_results.loc[combined_results['data_type'] == 'spurious_group', 'mean_accuracy'].values[0]:.4f}"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Aggregate evaluation results across different seeds"
+    )
+    parser.add_argument(
+        "--model-type",
+        type=str,
+        default="gpt-4o",
+        choices=SUPPORTED_MODELS,
+        help="type of the model",
+    )
+    parser.add_argument(
+        "--prompt-strategy",
+        type=str,
+        default="direct_prompting",
+        help="prompting strategy",
+    )
+    parser.add_argument(
+        "--anchor",
+        action="store_true",
+        help="aggregate anchor set results",
+    )
+    parser.add_argument(
+        "--spurious-group",
+        action="store_true",
+        help="aggregate spurious group set results",
+    )
+    parser.add_argument(
+        "--non-spurious",
+        action="store_true",
+        help="aggregate non-spurious set results",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/adhoc/evaluate.py
+++ b/adhoc/evaluate.py
@@ -49,6 +49,29 @@ def parse_predictions(predictions, args):
     return parsed
 
 
+def parse_only_for_split(save_dir: Path, split: str, seed: int, args):
+    """Load existing results CSV for a split and re-parse predictions in-place."""
+    file_map = {
+        "anchor": save_dir / f"anchor_seed_{seed}_eval_results.csv",
+        "spurious_group": save_dir / f"spurious_group_seed_{seed}_eval_results.csv",
+        "non_spurious": save_dir / f"non_spurious_seed_{seed}_eval_results.csv",
+    }
+    fpath = file_map[split]
+    if not fpath.exists():
+        print(f"[parse-only] Missing file for {split}: {fpath}")
+        return
+    df = pd.read_csv(fpath)
+    if "prediction" not in df.columns:
+        print(f"[parse-only] No 'prediction' column in {fpath}; skipping")
+        return
+    preds = df["prediction"].astype(str).tolist()
+    new_parsed = parse_predictions(preds, args)
+    df["parsed"] = new_parsed
+    df.to_csv(fpath, index=False)
+    acc = compute_acc(df)
+    print(f"[parse-only] {split} accuracy (seed {seed}): {acc}")
+
+
 def main(args):
     """
     Evaluates model on full benchmark to extract the error set
@@ -57,6 +80,23 @@ def main(args):
         Path(os.getenv("EVAL_HUMAN_ACCEPTED_DIR")) / "reference_anchor_set.csv"
     )
     anchor_set_df = pd.read_csv(anchor_set_path)
+
+    save_dir = (
+        Path(os.getenv("ADHOC_EVAL_RESULTS_DIR"))
+        / args.model_type
+        / f"{args.prompt_strategy}"
+    )
+
+    # If parse-only: skip generation and re-parse existing CSVs per selected splits
+    if args.parse_only:
+        if args.anchor:
+            parse_only_for_split(save_dir, "anchor", args.seed, args)
+        if args.spurious_group:
+            parse_only_for_split(save_dir, "spurious_group", args.seed, args)
+        if args.non_spurious:
+            parse_only_for_split(save_dir, "non_spurious", args.seed, args)
+        return
+
     anchor_predictions = []
     spurious_group_predictions = []
     non_spurious_predictions = []
@@ -95,11 +135,6 @@ def main(args):
             "answer": anchor_answers,
         }
         eval_results_df = pd.DataFrame(eval_results)
-        save_dir = (
-            Path(os.getenv("ADHOC_EVAL_RESULTS_DIR"))
-            / args.model_type
-            / f"{args.prompt_strategy}"
-        )
         save_dir.mkdir(parents=True, exist_ok=True)
         # Save DataFrame to a CSV file
         eval_results_df.to_csv(
@@ -146,11 +181,6 @@ def main(args):
             "answer": spurious_group_answers,
         }
         eval_results_df = pd.DataFrame(eval_results)
-        save_dir = (
-            Path(os.getenv("ADHOC_EVAL_RESULTS_DIR"))
-            / args.model_type
-            / f"{args.prompt_strategy}"
-        )
         save_dir.mkdir(parents=True, exist_ok=True)
         # Save DataFrame to a CSV file
         eval_results_df.to_csv(
@@ -234,6 +264,11 @@ if __name__ == "__main__":
         type=int,
         default=42,
         help="seed for the model",
+    )
+    parser.add_argument(
+        "--parse-only",
+        action="store_true",
+        help="Only re-parse existing prediction outputs; do not run model inference",
     )
     args = parser.parse_args()
     main(args)

--- a/adhoc/scripts/aggregate_seed_eval.sh
+++ b/adhoc/scripts/aggregate_seed_eval.sh
@@ -1,0 +1,25 @@
+# Run evaluate.py for all supported models in utils/constants.py
+
+SUPPORTED_MODELS=(
+    "gpt-4o"
+    "gpt-4o-mini"
+    "gemini-1.5-pro"
+    "gemini-2.0-flash"
+    "claude-3.7-sonnet"
+    "qwen-vl-max"
+    "qwen-vl-plus"
+    "qwen-2.5-7b"
+    "qwen-2.5-32b"
+    "llama-3.2-11b"
+    "llama-3.2-90b"
+    "llava-1.5"
+    "llava-1.6"
+    "o4-mini"
+    "o3"
+)
+
+for MODEL in "${SUPPORTED_MODELS[@]}"; do
+    echo "Running aggregate_seed_eval.py for model: $MODEL"
+    python3 adhoc/aggregate_seed_eval.py --model-type "$MODEL" --anchor --spurious-group --non-spurious --prompt-strategy "direct_prompting"
+done
+

--- a/adhoc/scripts/main_result.sh
+++ b/adhoc/scripts/main_result.sh
@@ -1,21 +1,22 @@
+#!/usr/bin/env bash
 # Run evaluate.py for all supported models in utils/constants.py
 
 SUPPORTED_MODELS=(
-    "gpt-4o"
-    "gpt-4o-mini"
+    # "gpt-4o"
+    # "gpt-4o-mini"
     "gemini-1.5-pro"
     "gemini-2.0-flash"
-    "claude-3.7-sonnet"
+    # "claude-3.7-sonnet"
     "qwen-vl-max"
     "qwen-vl-plus"
-    "qwen-2.5-7b"
-    "qwen-2.5-32b"
-    "llama-3.2-11b"
-    "llama-3.2-90b"
-    "llava-1.5"
-    "llava-1.6"
-    "o4-mini"
-    "o3"
+    # "qwen-2.5-7b"
+    # "qwen-2.5-32b"
+    # "llama-3.2-11b"
+    # "llama-3.2-90b"
+    # "llava-1.5"
+    # "llava-1.6"
+    # "o4-mini"
+    # "o3"
 )
 
 SEEDS=(42 332 1981 213 2901)
@@ -27,3 +28,9 @@ for MODEL in "${SUPPORTED_MODELS[@]}"; do
     done
 done
 
+# for MODEL in "${SUPPORTED_MODELS[@]}"; do
+#     echo "Running evaluate.py for model: $MODEL"
+#     for SEED in "${SEEDS[@]}"; do
+#         python adhoc/evaluate.py --model-type "$MODEL" --anchor --spurious-group --non-spurious --prompt-strategy "direct_prompting" --seed "$SEED" --parse-only
+#     done
+# done

--- a/curation/README.md
+++ b/curation/README.md
@@ -66,4 +66,4 @@ This document details the integration methods for each supported model type in t
 - [x] llava-1.5
 - [x] llava-1.6
 - [x] o4-mini (not supported in Response API)
-- [x] o3 (not supported in Response API)
+- [] o3 (not supported in Response API)

--- a/curation/engine.py
+++ b/curation/engine.py
@@ -195,8 +195,8 @@ class VLMInterface:
         if model_prefix == "gemini":
             try:
                 generation_config = GenerateContentConfig(
-                    temperature=0.2,
-                    top_p=1,
+                    temperature=0.7,
+                    top_p=0.9,
                     max_output_tokens=300,
                     response_mime_type="text/plain",
                     system_instruction=self.system_prompt,
@@ -247,6 +247,9 @@ class VLMInterface:
             output = self.model.generate(
                 **inputs,
                 max_new_tokens=100,
+                do_sample=True,
+                temperature=0.7,
+                top_p=0.9,
                 return_dict_in_generate=True,
                 output_scores=True,
             )
@@ -499,6 +502,8 @@ class VLMInterface:
                     messages=context,
                     max_tokens=300,
                     seed=self.seed,
+                    temperature=0.7,
+                    top_p=0.9,
                 )
                 return response.choices[0].message.content
             except Exception as e:

--- a/utils/data_preparation.py
+++ b/utils/data_preparation.py
@@ -102,34 +102,51 @@ def get_is_filtered_benchmark_id_set(benchmark):
 
 
 def parse_data(data):
-    if "A)" in data:
-        return "A"
-    elif "B)" in data:
-        return "B"
-    elif "C)" in data:
-        return "C"
-    elif "D)" in data:
-        return "D"
-    elif "E)" in data:
+    """
+    Robustly parse a multiple-choice answer from free-form model output.
+    Priority:
+      1) A line that is exactly one of: (A), (B), (C), (D) or A/B/C/D
+      2) Phrases like 'final answer: (B)' or 'answer: C'
+      3) Parenthesized choice anywhere, prefer the last occurrence
+    Avoid naive substring checks to prevent defaulting to 'A'.
+    Return 'E' if nothing reliable is found.
+    """
+    import re
+
+    if not isinstance(data, str):
         return "E"
-    elif "A." in data:
-        return "A"
-    elif "B." in data:
-        return "B"
-    elif "C." in data:
-        return "C"
-    elif "D." in data:
-        return "D"
-    elif "A" in data:
-        return "A"
-    elif "B" in data:
-        return "B"
-    elif "C" in data:
-        return "C"
-    elif "D" in data:
-        return "D"
-    elif "E" in data:
+
+    text = data.strip()
+    if not text:
         return "E"
+
+    # 1) Check line-by-line from bottom: exact single-letter choice
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    for ln in reversed(lines):
+        # Exact (X) or X
+        m = re.fullmatch(r"\(?([A-E])\)?", ln, flags=re.IGNORECASE)
+        if m:
+            return m.group(1).upper()
+
+    # 2) Look for explicit 'final answer' or 'answer' cues
+    m = re.search(r"final\s*answer\s*[:\-]?\s*\(?([A-E])\)?", text, flags=re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    m = re.search(r"answer\s*[:\-]?\s*\(?([A-E])\)?", text, flags=re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+
+    # 3) Any parenthesized choice; prefer the last one in the text
+    candidates = re.findall(r"\(([A-E])\)", text, flags=re.IGNORECASE)
+    if candidates:
+        return candidates[-1].upper()
+
+    # 4) Fallback: look for standalone letters surrounded by non-letters (less likely to collide)
+    m = re.search(r"\b([A-E])\b", text, flags=re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+
+    return "E"
 
 
 def parse_data_w_gpt(data, client):
@@ -176,16 +193,27 @@ def parse_data_w_gpt(data, client):
 
 
 def parse_llava_data(data):
+    """
+    LLaVA-1.6 outputs can contain multiple [/INST] markers due to the chat template.
+    Extract the content strictly after the LAST [/INST] and parse that.
+    """
+    import re
 
-    # Extract the text after [/INST]
-    result = re.search(r"\[/INST\](.*)", data, re.DOTALL)
+    if not isinstance(data, str) or not data.strip():
+        return "E"
 
-    # Output the extracted text
-    if result:
-        ret = result.group(1).strip()
+    # Split on [/INST] and take the segment after the last occurrence
+    parts = re.split(r"\[/INST\]", data, flags=re.DOTALL)
+    if len(parts) >= 2:
+        ret = parts[-1].strip()
     else:
-        print("No text found after [/INST].")
-        ret = "(E)"
+        # Fallback to previous behavior (first match) if no split worked
+        m = re.search(r"\[/INST\](.*)", data, re.DOTALL)
+        ret = m.group(1).strip() if m else "(E)"
+
+    # Sometimes responses may still include role prefixes; trim obvious ones
+    # e.g., "ASSISTANT:" or similar headers
+    ret = re.sub(r"^(ASSISTANT:|Assistant:|assistant:)\s*", "", ret)
 
     return parse_data(ret)
 


### PR DESCRIPTION
## Summary
- Add multi-seed evaluation aggregation (`adhoc/aggregate_seed_eval.py` + driver script): computes mean ± std accuracy across the 5 seeds per model/prompt-strategy/data-type and reports non-spurious − anchor / − spurious-group deltas.
- Add a `--parse-only` mode to `adhoc/evaluate.py` to re-parse existing prediction CSVs without re-running inference.
- Make answer parsing in `utils/data_preparation.py` more robust (prioritized regex instead of naive substring matching) and fix a fall-through bug that returned `None` instead of `"E"`.
- Switch several VLM backends to sampling (temperature 0.7 / top_p 0.9) in `curation/engine.py`.
- Add paper ([arXiv:2506.18322](https://arxiv.org/pdf/2506.18322)) and Hugging Face dataset links + citation to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)